### PR TITLE
Only enable backdrop tap event as needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ install();
 | mainContent         | `undefined`                       | `View`                      | View containing the main content of the app             |
 | gestureEnabled      | `true`                            | `boolean`                   | Boolean setting if swipe gestures are enabled           |
 | backdropColor       | `new Color('rgba(0, 0, 0, 0.7)')` | `Color`                     | The color of the backdrop behind the drawer             |
-| leftDrawerMode      | `slide`                           | `Mode ('under' or 'slide')` | The color of the backdrop behind the drawer             |
-| rightDrawerMode     | `slide`                           | `Mode ('under' or 'slide')` | The color of the backdrop behind the drawer             |
+| leftDrawerMode      | `slide`                           | `Mode ('under' or 'slide')` | The drawer's enter-animation behavior             |
+| rightDrawerMode     | `slide`                           | `Mode ('under' or 'slide')` | The drawer's enter-animation behavior             |
 | gestureMinDist     | `10`                           | number | The min "swipe" distance to trigger the menu gesture             |
 | gestureHandlerOptions     | `null`                           | PanGestureHandlerOptions | Options to customize the pan gesture handler             |
 | leftSwipeDistance     | `40`                           | number | The "left" zone size from where the gesture is recognized             |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ install();
 | bottomDrawer         | `undefined`                       | `View`                      | View containing the content for the bottom side drawer   |
 | mainContent         | `undefined`                       | `View`                      | View containing the main content of the app             |
 | gestureEnabled      | `true`                            | `boolean`                   | Boolean setting if swipe gestures are enabled           |
+| backdropTapGestureEnabled      | `true`                            | `boolean`                   | Allow tapping the backdrop to close the drawer           |
 | backdropColor       | `new Color('rgba(0, 0, 0, 0.7)')` | `Color`                     | The color of the backdrop behind the drawer             |
 | leftDrawerMode      | `slide`                           | `Mode ('under' or 'slide')` | The drawer's enter-animation behavior             |
 | rightDrawerMode     | `slide`                           | `Mode ('under' or 'slide')` | The drawer's enter-animation behavior             |

--- a/packages/ui-drawer/blueprint.md
+++ b/packages/ui-drawer/blueprint.md
@@ -34,9 +34,10 @@ install();
 | bottomDrawer         | `undefined`                       | `View`                      | View containing the content for the bottom side drawer   |
 | mainContent         | `undefined`                       | `View`                      | View containing the main content of the app             |
 | gestureEnabled      | `true`                            | `boolean`                   | Boolean setting if swipe gestures are enabled           |
+| backdropTapGestureEnabled       | `true` | `boolean`                     | Allow tapping the backdrop to close the drawer             |
 | backdropColor       | `new Color('rgba(0, 0, 0, 0.7)')` | `Color`                     | The color of the backdrop behind the drawer             |
-| leftDrawerMode      | `slide`                           | `Mode ('under' or 'slide')` | The color of the backdrop behind the drawer             |
-| rightDrawerMode     | `slide`                           | `Mode ('under' or 'slide')` | The color of the backdrop behind the drawer             |
+| leftDrawerMode      | `slide`                           | `Mode ('under' or 'slide')` | The drawer's enter-animation behavior             |
+| rightDrawerMode     | `slide`                           | `Mode ('under' or 'slide')` | The drawer's enter-animation behavior             |
 | gestureMinDist     | `10`                           | number | The min "swipe" distance to trigger the menu gesture             |
 | gestureHandlerOptions     | `null`                           | PanGestureHandlerOptions | Options to customize the pan gesture handler             |
 | leftSwipeDistance     | `40`                           | number | The "left" zone size from where the gesture is recognized             |

--- a/src/ui-drawer/index.ts
+++ b/src/ui-drawer/index.ts
@@ -157,9 +157,7 @@ export class Drawer extends GridLayout {
         this.insertChild(this.backDrop, 0);
     }
     onBackdropTap() {
-        if (this.backdropTapGestureEnabled) {
-            this.close();
-        }
+        this.close();
     }
     initGestures() {
         const manager = Manager.getInstance();
@@ -177,7 +175,9 @@ export class Drawer extends GridLayout {
     }
     initNativeView() {
         super.initNativeView();
-        this.backDrop.on('tap', this.onBackdropTap, this);
+        if (this.backdropTapGestureEnabled) {
+            this.backDrop.on('tap', this.onBackdropTap, this);
+        }
         if (this.gestureEnabled) {
             this.initGestures();
         }


### PR DESCRIPTION
Noticed a couple missing documentation items that I fixed (I'm open to better wording on those). 

But the main point of this PR is:
- document that `backdropTapGestureEnabled` is an option for `Drawer`
- only add the `tap` event to the backdrop _as needed_

The reason for this is if you have `enableGlobalTapAnimations` set to true in your NativeScript project, it animates anything with a `tap` event. This can cause unexpected weirdness with the backdrop. For example, I want to scale down and change the opacity on touch. The scaling especially doesn't work with the backdrop:

![2023-01-24 08 54 55](https://user-images.githubusercontent.com/25620449/214327824-a605de4f-30cf-4245-839c-611bb8c0dc51.gif).
